### PR TITLE
Use DefaultItemExcludes instead of custom compile item modifications.

### DIFF
--- a/MultipleProjecsInSameFolder/multiprojecttest_project1.csproj
+++ b/MultipleProjecsInSameFolder/multiprojecttest_project1.csproj
@@ -7,12 +7,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputPath>bin\$(Configuration)\$(TargetFramework)\$(MSBuildProjectName)</OutputPath>
+    <DefaultItemExcludes>$(DefaultItemExcludes);obj\**</DefaultItemExcludes>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-
-  <ItemGroup>
-    <Compile Remove="obj\\**\*" />
-    <Compile Include="obj\$(MSBuildProjectName)\**\$(MSBuildProjectName).AssemblyInfo.cs" />
-  </ItemGroup>
 </Project>

--- a/MultipleProjecsInSameFolder/multiprojecttest_project2.csproj
+++ b/MultipleProjecsInSameFolder/multiprojecttest_project2.csproj
@@ -7,12 +7,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputPath>bin\$(Configuration)\$(TargetFramework)\$(MSBuildProjectName)</OutputPath>
+    <DefaultItemExcludes>$(DefaultItemExcludes);obj\**</DefaultItemExcludes>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-
-   <ItemGroup>
-    <Compile Remove="obj\\**\*" />
-    <Compile Include="obj\$(MSBuildProjectName)\**\$(MSBuildProjectName).AssemblyInfo.cs" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Other approach that makes sure that:

* No paths need to be hardcoded for `Compile` items.
* All the things in `obj` of other projects don't potentially show up as `None` items.
* Since `OutputPath` already contains `$(TargetFramework)`, disable automatic appending of the TFM.